### PR TITLE
Adding apt-get update prior to installing curl

### DIFF
--- a/scripts/install_st2.sh
+++ b/scripts/install_st2.sh
@@ -20,6 +20,7 @@ if [[ -n "$RHTEST" ]]; then
   sudo yum update -y curl nss
 elif [[ -n "$DEBTEST" ]]; then
   echo "*** Detected Distro is ${DEBTEST} ***"
+  sudo apt-get update
   sudo apt-get install -y curl
 else
   echo "Unknown Operating System."


### PR DESCRIPTION
This will avoid out-of-sync repos that can cause 404 errors when old packages in apt-cache are deprecated.