### PR TITLE
Adding xenial as default image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-.vagrant
+.vagrant*

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,7 @@
 
 release    = ENV['RELEASE'] ? ENV['RELEASE'] : 'stable'
 hostname   = ENV['HOSTNAME'] ? ENV['HOSTNAME'] : 'st2vagrant'
-box        = ENV['BOX'] ? ENV['BOX'] : 'ubuntu/trusty64'
+box        = ENV['BOX'] ? ENV['BOX'] : 'ubuntu/xenial64'
 st2user    = ENV['ST2USER'] ? ENV['ST2USER']: 'st2admin'
 st2passwd  = ENV['ST2PASSWORD'] ? ENV['ST2PASSWORD'] : 'Ch@ngeMe'
 


### PR DESCRIPTION
Makes xenial default image for st2vagrant. Also adds wildcard for vagrant gitingore entry to block additional vagrant folder locations. 