### PR TITLE
[RFR] [WIP] Improve ability to specify packages to install

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,17 +1,29 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-release    = ENV['RELEASE'] ? ENV['RELEASE'] : 'stable'
-hostname   = ENV['HOSTNAME'] ? ENV['HOSTNAME'] : 'st2vagrant'
-box        = ENV['BOX'] ? ENV['BOX'] : 'ubuntu/xenial64'
-st2user    = ENV['ST2USER'] ? ENV['ST2USER']: 'st2admin'
-st2passwd  = ENV['ST2PASSWORD'] ? ENV['ST2PASSWORD'] : 'Ch@ngeMe'
-
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
 
+hostname    = ENV['HOSTNAME'] ? ENV['HOSTNAME'] : 'st2vagrant'
+box         = ENV['BOX'] ? ENV['BOX'] : 'ubuntu/xenial64'
+
+# VM's IP address
+vm_ip       = ENV['VM_IP'] ? ENV['VM_IP'] : '192.168.16.40'
+
+# Release type: 'stable' or the default 'unstable'
+release     = ENV['RELEASE'] ? ENV['RELEASE'] : 'unstable'
+
+# Non-empty license key implies enterprise
+license_key = ENV['LICENSE_KEY'] ? '-k ' + ENV['LICENSE_KEY'] : ''
+
+# 'staging' or the default empty string
+repo_type   = ENV['REPO_TYPE'] ? '-t ' + ENV['REPO_TYPE'] : ''
+
+st2user     = ENV['ST2USER'] ? ENV['ST2USER']: 'st2admin'
+st2passwd   = ENV['ST2PASSWORD'] ? ENV['ST2PASSWORD'] : 'Ch@ngeMe'
+
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.define "st2" do |st2|
+  config.vm.define "#{hostname}" do |st2|
     # Box details
     st2.vm.box = "#{box}"
     st2.vm.hostname = "#{hostname}"
@@ -28,7 +40,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # config.vm.synced_folder "/path/to/directory/on/host", "/opt/stackstorm/packs", :nfs => true, :mount_options => ['nfsvers=3']
 
     # Configure a private network
-    st2.vm.network :private_network, ip: "192.168.16.20"
+    st2.vm.network :private_network, ip: "#{vm_ip}"
 
     # Public (bridged) network may come handy for external access to VM (e.g. sensor development)
     # See https://www.vagrantup.com/docs/networking/public_network.html
@@ -37,7 +49,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # Start shell provisioning.
     st2.vm.provision "shell" do |s|
       s.path = "scripts/install_st2.sh"
-      s.args   = "#{st2user} #{st2passwd} #{release}"
+      s.args   = "-u #{st2user} -p #{st2passwd} -r #{release} #{license_key} #{repo_type}"
       s.privileged = false
     end
   end


### PR DESCRIPTION
It should be easier to setup the vagrant VM with the desired packages.

The license_key, repo_type and vm_ip variables were added to the `Vagrantfile`. The necessary parameters are passed to `scripts/install.sh` using option args.

Modified `scripts/install.sh` to use option args. If the `license_key` is defined, then the enterprise installation script is run... else, as before, the community installation script is run.