### PR TITLE
Added ability to specify version for use during release testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Environment variables can be used to enable or disable certain features of the S
 * `BOX` - the Vagrant base box to use. DEFAULT: `ubuntu/xenial64`
 * `ST2USER` - Username for st2. DEFAULT: st2admin
 * `ST2PASSWORD` - Password for st2. DEFAULT: `Ch@ngeMe`
+* `VERSION` - the version of StackStorm to install: `3.2`
 
 Set the variables by pre-pending them to `vagrant up` command. In the example below, it will install
 a version of st2 from development trunc, and set password to `secret`:
@@ -302,6 +303,14 @@ exports:3: using fallback (marked offline): /Volumes/Repo
 ```
 FIX: Remove residuals from `/etc/exports` file on the host machine, and do `vagrant reload` again.
 
+
+## Using st2vagrant for release testing
+
+Creates a box from a specific development version of code:
+
+``` bash
+BOX=centos/7 RELEASE=unstable VERSION=3.1dev vagrant up
+```
 
 ## Support
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -67,6 +67,12 @@ release     = ENV['RELEASE'] ? '-r "' + ENV['RELEASE'] + '"' : '-r unstable'
 # REPO_TYPE=staging
 repo_type   = ENV['REPO_TYPE'] ? '-t ' + ENV['REPO_TYPE'] : ''
 
+# Which version of the package to install
+# Default: (empty string, meaning latest)
+# RELEASE=3.1dev
+# RELEASE=3.2
+version     = ENV['VERSION'] ? '-v "' + ENV['VERSION'] + '"' : ''
+
 # Build source - used to install packages from a specific CircleCI build
 # Default: Packagecloud
 # Examples:
@@ -216,7 +222,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # Start shell provisioning.
     st2.vm.provision "shell" do |s|
       s.path = "scripts/install_st2.sh"
-      s.args   = "#{st2user} #{st2passwd} #{release} #{repo_type} #{dev} #{branch} #{license_key}"
+      s.args   = "#{st2user} #{st2passwd} #{release} #{repo_type} #{dev} #{branch} #{license_key} #{version}"
       s.privileged = false
     end
   end

--- a/scripts/install_st2.sh
+++ b/scripts/install_st2.sh
@@ -4,7 +4,7 @@ set -e
 
 echo "$@"
 
-while getopts "u:p:r:t:d:b:k:" option; do
+while getopts "u:p:r:t:d:b:k:v:" option; do
   case "${option}" in
     u) ST2_USER=${OPTARG};;
     p) ST2_PASSWORD=${OPTARG};;
@@ -13,6 +13,7 @@ while getopts "u:p:r:t:d:b:k:" option; do
     d) DEV="--dev=${OPTARG}";;
     b) BRANCH=${OPTARG};;
     k) LICENSE_KEY=${OPTARG};;
+    v) VERSION=${OPTARG};;
   esac
 done
 
@@ -30,6 +31,10 @@ if [[ "$REPO_TYPE" == "staging" ]]; then
 fi
 
 BRANCH_FLAG="--force-branch=$BRANCH"
+
+if [[ -n "$VERSION" ]]; then
+  VERSION_FLAG="--version=${VERSION}"
+fi
 
 
 echo "*** Let's install some net tools ***"
@@ -96,9 +101,9 @@ fi
 echo "*** Let's install StackStorm  ***"
 
 if [[ -n "$LICENSE_KEY" ]]; then
-  echo "--user=$ST2_USER --password=$ST2_PASSWORD $DEV $BRANCH_FLAG $RELEASE_FLAG --license=$LICENSE_KEY"
-  curl -sSL https://raw.githubusercontent.com/StackStorm/bwc-installer/$BRANCH/scripts/bwc-installer.sh | bash -s -- --user=$ST2_USER --password=$ST2_PASSWORD $DEV $BRANCH_FLAG $RELEASE_FLAG $REPO_TYPE --license=$LICENSE_KEY
+  echo "--user=$ST2_USER --password=$ST2_PASSWORD $DEV $BRANCH_FLAG $RELEASE_FLAG $VERSION_FLAG --license=$LICENSE_KEY"
+  curl -sSL https://raw.githubusercontent.com/StackStorm/bwc-installer/$BRANCH/scripts/bwc-installer.sh | bash -s -- --user=$ST2_USER --password=$ST2_PASSWORD $DEV $BRANCH_FLAG $RELEASE_FLAG $REPO_TYPE $VERSION_FLAG --license=$LICENSE_KEY
 else
-  echo "--user=$ST2_USER --password=$ST2_PASSWORD $DEV $BRANCH_FLAG $RELEASE_FLAG"
-  curl -sSL https://raw.githubusercontent.com/StackStorm/st2-packages/$BRANCH/scripts/st2_bootstrap.sh | bash -s -- --user=$ST2_USER --password=$ST2_PASSWORD $DEV $BRANCH_FLAG $RELEASE_FLAG $REPO_TYPE
+  echo "--user=$ST2_USER --password=$ST2_PASSWORD $DEV $BRANCH_FLAG $RELEASE_FLAG $VERSION_FLAG"
+  curl -sSL https://raw.githubusercontent.com/StackStorm/st2-packages/$BRANCH/scripts/st2_bootstrap.sh | bash -s -- --user=$ST2_USER --password=$ST2_PASSWORD $DEV $BRANCH_FLAG $RELEASE_FLAG $REPO_TYPE $VERSION_FLAG
 fi


### PR DESCRIPTION
Trying to following @arma's instructions for release testing and i couldn't specify `--version` in the Vagrant box.

This adds the flag :)