### PR TITLE
Renamed HOSTNAME variable to VAGRANT_HOSTNAME to prevent clashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ If something went wrong, jump to [Troubleshooting](https://github.com/StackStorm
 Environment variables can be used to enable or disable certain features of the StackStorm installation:
 
 * `RELEASE` - `stable` for the latest stable release, or `unstable` for a current version from dev trunk. DEFAULT: `stable`
-* `HOSTNAME` - the hostname to give the VM. DEFAULT: `st2vagrant`
+* `VAGRANT_HOSTNAME` - the hostname to give the VM. DEFAULT: `st2vagrant`
 * `BOX` - the Vagrant base box to use. DEFAULT: `ubuntu/xenial64`
 * `ST2USER` - Username for st2. DEFAULT: st2admin
 * `ST2PASSWORD` - Password for st2. DEFAULT: `Ch@ngeMe`

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -35,9 +35,13 @@ vm_box         = ENV['BOX'] ? ENV['BOX'] : 'ubuntu/xenial64'
 # The hostname of the Vagrant VM
 # Default: st2vagrant
 # Examples:
-# HOSTNAME=st2vagrant-rhel7
-# HOSTNAME=rhel7-testing
-vm_hostname    = ENV['HOSTNAME'] ? ENV['HOSTNAME'] : 'st2vagrant'
+# VAGRANT_HOSTNAME=st2vagrant-rhel7
+# VAGRANT_HOSTNAME=rhel7-testing
+#
+# Note, we specifically do NOT name this "HOSTNAME" because that is a
+# common environment variable and will set the vagrant VM's hostname to the
+# same as the hypervisor host running the vagrant VM.
+vm_hostname = ENV['VAGRANT_HOSTNAME'] ? ENV['VAGRANT_HOSTNAME'] : 'st2vagrant'
 
 # The IP address to assign to the VM
 # Default: 192.168.16.20


### PR DESCRIPTION
In RHEL based OSes the `HOSTNAME` environment variable is set to the current hostname.

This clashes with when running `st2vagrant` because we used the HOSTNAME environment variable. The end result was a vagrant box that always had the same hostname as the hypervisor that was running vagrant (your laptop).

This changes our variable used to override hostname to `VAGRANT_HOSTNAME` in order to prevent clashing.